### PR TITLE
Fix a multi core problem in AArch64

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -44,6 +44,7 @@ cfg_if::cfg_if! {
         mod interrupts {
             pub(crate) fn cpu_id() -> u8 {
                 use cortex_a::registers::MPIDR_EL1;
+                use tock_registers::interfaces::Readable;
                 (MPIDR_EL1.get() & 0xf) as u8
             }
             pub(crate) fn intr_on() {

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -43,7 +43,8 @@ cfg_if::cfg_if! {
     } else if #[cfg(all(target_os = "none", target_arch = "aarch64"))] {
         mod interrupts {
             pub(crate) fn cpu_id() -> u8 {
-                0
+                use cortex_a::registers::MPIDR_EL1;
+                (MPIDR_EL1.get() & 0xf) as u8
             }
             pub(crate) fn intr_on() {
                 unsafe {


### PR DESCRIPTION
Get current core id in aarch64 interrupt, to avoid problems in multi core environment.